### PR TITLE
Simplify Plugin Loading Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ the above results in the following console output:
 ## Actual Benefit of AFT
 the AFT-Core package on it's own contains some helpers for testing, but the actual benefit comes from the plugins. Because the above logging will also send to any registered logging plugins, it becomes easy to create loggers that send to any external system such as TestRail or to log results to Elasticsearch.
 ### Logging Plugin
-to create a logging plugin you simply need to implment the `ILoggingPlugin` interface and add `@ILoggingPlugin.register` above the class.
+to create a logging plugin you simply need to implment the `ILoggingPlugin` interface in a class with a constructor accepting no arguments. Then, in your `aftconfig.json` add the following (where your `ILoggingPlugin` implementations are contained in files at `./relative/path/to/logging-plugin1.ts` and `/full/path/to/logging-plugin2.ts`):
+```json
+{
+    "logging_plugins": "./relative/path/to/logging-plugin1,/full/path/to/logging-plugin2"
+}
+```
+```
+NOTE: if the plugins are referenced as external npm packages you may leave off the path and just reference by package name
+```
+#### Example Logging Plugin
 ```typescript
-@ILoggingPlugin.register
 export class ExternalLogger implements ILoggingPlugin {
     name: string = 'externallogger';
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
-      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+      "version": "12.12.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
+      "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==",
       "dev": true
     },
     "@types/uuid": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-core",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Automation Framework for Testing (AFT) package supporting JavaScript unit, integration and functional testing",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^3.4.4",
-    "@types/node": "^12.7.12",
+    "@types/node": "^12.12.35",
     "@types/uuid": "3.4.6",
     "jasmine": "^3.5.0",
     "typescript": "^3.6.4"

--- a/src/construction/plugin-loader.ts
+++ b/src/construction/plugin-loader.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+
+export module PluginLoader {
+    export async function load<T>(...pluginNames: string[]): Promise<T[]> {
+        let plugins: T[] = [];
+        for (var i=0; i<pluginNames.length; i++) {
+            let p: T = await validatePlugin<T>(pluginNames[i]);
+            if (p) {
+                plugins.push(p);
+            }
+        }
+        return plugins;
+    }
+
+    async function validatePlugin<T>(pluginName: string): Promise<T> {
+        var plugin;
+
+        try {
+            plugin  = await import(pluginName);
+        } catch (e) {
+            try {
+                let pathToPlugin: string = path.resolve(process.cwd(), pluginName);
+                plugin = await import(pathToPlugin);
+            } catch (ee) {
+                console.warn(`unable to load plugin: '${pluginName}' due to: ${ee}`);
+            }
+        }
+        if (plugin) {
+            try {
+                let constructorName: string = Object.keys(plugin)[0];
+                return new plugin[constructorName]();
+            } catch (e) {
+                console.warn(`unable to create instance of loaded plugin '${pluginName}' due to: ${e}`);
+            }
+        }
+        return null as T;
+    }
+}

--- a/src/logging/plugins/ilogging-plugin.ts
+++ b/src/logging/plugins/ilogging-plugin.ts
@@ -1,6 +1,5 @@
 import { TestLogLevel } from "../test-log-level";
 import { TestResult } from "../../integrations/test-cases/test-result";
-import { Constructor } from "../../construction/constructor";
 
 export interface ILoggingPlugin {
     name: string;
@@ -10,15 +9,4 @@ export interface ILoggingPlugin {
     log(level: TestLogLevel, message: string): Promise<void>;
     logResult(result: TestResult): Promise<void>;
     finalise(): Promise<void>;
-}
-
-export namespace ILoggingPlugin {
-    const pluginConstructors: Constructor<ILoggingPlugin>[] = [];
-    export function getPluginConstructors(): Constructor<ILoggingPlugin>[] {
-        return pluginConstructors;
-    }
-    export function register<T extends Constructor<ILoggingPlugin>>(ctor: T) {
-        pluginConstructors.push(ctor);
-        return ctor;
-    }
 }

--- a/src/logging/test-log-options.ts
+++ b/src/logging/test-log-options.ts
@@ -8,6 +8,7 @@ import '../extensions/string-extensions';
 export class TestLogOptions implements IInitialiseOptions {
     name: string;
     level: TestLogLevel;
+    pluginNames: string[];
 
     constructor(name: string) {
         this.name = this.formatName(name);
@@ -25,15 +26,25 @@ export class TestLogOptions implements IInitialiseOptions {
 
 export module TestLogOptions {
     export var LOGLEVEL_KEY: string = 'testloglevel';
+    export var PLUGINS_KEY: string = 'logging_plugins';
 
     export async function level(lvl?: TestLogLevel): Promise<TestLogLevel> {
         if (lvl) {
             TestConfig.setGlobalValue(LOGLEVEL_KEY, lvl.name);
         }
         
-        let levelStr: string = await TestConfig.getValueOrDefault('testloglevel', TestLogLevel.info.name);
+        let levelStr: string = await TestConfig.getValueOrDefault(LOGLEVEL_KEY, TestLogLevel.info.name);
         let level = TestLogLevel.parse(levelStr);
         
         return level;
+    }
+
+    export async function pluginNames(...pluginNames: string[]): Promise<string[]> {
+        if (pluginNames && pluginNames.length > 0) {
+            TestConfig.setGlobalValue(PLUGINS_KEY, pluginNames.join(','));
+        }
+        
+        let pNames: string = await TestConfig.getValueOrDefault(PLUGINS_KEY);
+        return (pNames) ? pNames.split(',') : [];
     }
 }

--- a/src/logging/test-log.ts
+++ b/src/logging/test-log.ts
@@ -3,27 +3,16 @@ import { TestResult } from "../integrations/test-cases/test-result";
 import { ILoggingPlugin } from "./plugins/ilogging-plugin";
 import { IDisposable } from "../helpers/idisposable";
 import { TestLogLevel } from "./test-log-level";
-import { Constructor } from "../construction/constructor";
+import { PluginLoader } from "../construction/plugin-loader";
 
 export class TestLog implements IDisposable {
     name: string;
     stepCount: number = 0;
     options: TestLogOptions;
-
-    private plugins: ILoggingPlugin[] = [];
     
     constructor(options: TestLogOptions) {
         this.name = options.name;
         this.options = options;
-        // create plugin instances unique to this logger
-        let pluginCtors: Constructor<ILoggingPlugin>[] = ILoggingPlugin.getPluginConstructors();
-        for (var i=0; i<pluginCtors.length; i++) {
-            try {
-                this.plugins.push(new pluginCtors[i]());
-            } catch (e) {
-                this.warn(`unable to create instance of ILoggingPlugin due to: ${e}`);
-            }
-        }
     }
 
     private _lvl: TestLogLevel;
@@ -32,6 +21,15 @@ export class TestLog implements IDisposable {
             this._lvl = this.options.level || await TestLogOptions.level();
         }
         return this._lvl;
+    }
+
+    private _plugins: ILoggingPlugin[];
+    async plugins(): Promise<ILoggingPlugin[]> {
+        if (!this._plugins) {
+            let names: string[] = this.options.pluginNames || await TestLogOptions.pluginNames();
+            this._plugins = await PluginLoader.load<ILoggingPlugin>(...names);
+        }
+        return this._plugins;
     }
 
     async trace(message: string): Promise<void> {
@@ -72,8 +70,9 @@ export class TestLog implements IDisposable {
             console.log(TestLog.format(this.name, level, message));
         }
         
-        for (var i=0; i<this.plugins.length; i++) {
-            let p: ILoggingPlugin = this.plugins[i];
+        let plugins: ILoggingPlugin[] = await this.plugins();
+        for (var i=0; i<plugins.length; i++) {
+            let p: ILoggingPlugin = plugins[i];
             try {
                 let enabled: boolean = await p.enabled();
                 if (enabled) {
@@ -86,8 +85,9 @@ export class TestLog implements IDisposable {
     }
 
     async logResult(result: TestResult): Promise<void> {
-        for (var i=0; i<this.plugins.length; i++) {
-            let p: ILoggingPlugin = this.plugins[i];
+        let plugins: ILoggingPlugin[] = await this.plugins();
+        for (var i=0; i<plugins.length; i++) {
+            let p: ILoggingPlugin = plugins[i];
             try {
                 let enabled: boolean = await p.enabled();
                 if (enabled) {
@@ -101,12 +101,13 @@ export class TestLog implements IDisposable {
     }
 
     async dispose(error?: Error): Promise<void> {
-        for (var i=0; i<this.plugins.length; i++) {
-            let p: ILoggingPlugin = this.plugins[i];
+        let plugins: ILoggingPlugin[] = await this.plugins();
+        for (var i=0; i<plugins.length; i++) {
+            let p: ILoggingPlugin = plugins[i];
             try {
                 let enabled: boolean = await p.enabled();
                 if (enabled) {
-                    await this.plugins[i].finalise();
+                    await plugins[i].finalise();
                 }
             } catch (e) {
                 console.log(TestLog.format(this.name, TestLogLevel.warn, `unable to call finalise on ${p.name} due to: ${e}`))

--- a/test/logging/fake-logger.ts
+++ b/test/logging/fake-logger.ts
@@ -1,0 +1,29 @@
+import { ILoggingPlugin } from "../../src/logging/plugins/ilogging-plugin";
+import { LoggingPluginStore } from "./logging-plugin-store";
+import { TestLogLevel } from "../../src/logging/test-log-level";
+import { LogMessage } from "./log-message";
+import { TestResult } from "../../src/integrations/test-cases/test-result";
+
+export class FakeLogger implements ILoggingPlugin {
+    name: string = 'fakelogger';
+    
+    async level(): Promise<TestLogLevel> {
+        return LoggingPluginStore.lvl;
+    }
+
+    async enabled(): Promise<boolean> {
+        return LoggingPluginStore.en;
+    }
+
+    async log(level: TestLogLevel, message: string): Promise<void> {
+        LoggingPluginStore.logs.push(new LogMessage(level, message));
+    }
+
+    async logResult(result: TestResult): Promise<void> {
+        LoggingPluginStore.results.push(result);
+    }
+
+    async finalise(): Promise<void> {
+        LoggingPluginStore.finalised = true;
+    }
+}

--- a/test/logging/log-message.ts
+++ b/test/logging/log-message.ts
@@ -1,0 +1,10 @@
+import { TestLogLevel } from "../../src/logging/test-log-level";
+
+export class LogMessage {
+    level: TestLogLevel;
+    message: string;
+    constructor(level: TestLogLevel, message: string) {
+        this.level = level;
+        this.message = message;
+    }
+}

--- a/test/logging/logging-plugin-store.ts
+++ b/test/logging/logging-plugin-store.ts
@@ -1,0 +1,19 @@
+import { TestLogLevel } from "../../src/logging/test-log-level";
+import { TestResult } from "../../src/integrations/test-cases/test-result";
+import { LogMessage } from "./log-message";
+
+export module LoggingPluginStore {
+    export var logs: LogMessage[] = [];
+    export var results: TestResult[] = [];
+    export var lvl: TestLogLevel = TestLogLevel.info;
+    export var en: boolean = true;
+    export var finalised: boolean = false;
+
+    export function reset() {
+        logs = [];
+        results = [];
+        lvl = TestLogLevel.info;
+        en = true;
+        finalised = false;
+    }
+}


### PR DESCRIPTION
### Changes:
* removing plugin registration via experimental attributes and instead using aftconfig.json property to list plugins as this provides a straightforward means of listing which plugins should be used while allowing for optionally excluding plugins that are referenced by the test project's packages.json by simply not including them in the config.